### PR TITLE
call UIAppliaction method on main thread

### DIFF
--- a/ExponeaSDK.podspec
+++ b/ExponeaSDK.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   #
 
   s.name         = "ExponeaSDK"
-  s.version      = "2.7.0"
+  s.version      = "2.7.1"
   s.summary      = "Exponea SDK used to track and fetch data from Exponea Experience Cloud."
 
   # This description is used to generate tags and improve search results.
@@ -59,7 +59,7 @@ Pod::Spec.new do |s|
   #
 
   s.platform     = :ios, "10.3"
-  s.swift_version = '4.2.0'
+  s.swift_versions = ['4.2', '5']
 
   # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
   #

--- a/ExponeaSDK/ExponeaSDK/Classes/Push Notifications/PushNotificationManager.swift
+++ b/ExponeaSDK/ExponeaSDK/Classes/Push Notifications/PushNotificationManager.swift
@@ -71,7 +71,9 @@ class PushNotificationManager: NSObject, PushNotificationManagerType {
         // push notifications unless enabled by developer in configuration
         if requirePushAuthorization {
             UNAuthorizationStatusProvider.current.isAuthorized { authorized in
-                if authorized { UIApplication.shared.registerForRemoteNotifications() }
+                if authorized {
+                    DispatchQueue.main.async { UIApplication.shared.registerForRemoteNotifications() }
+                }
             }
         } else {
             UIApplication.shared.registerForRemoteNotifications()


### PR DESCRIPTION
from `UNUserNotificationCenter.requestAuthorization(options:, completionHandler:)` docs:

```
completionHandler
The block to execute asynchronously with the results. This block may be executed on a background thread.
```

`UIApplication.shared` methods should be called on main thread.