### PR TITLE
Fix InAppMessageWebView in Swift 5.7

### DIFF
--- a/ExponeaSDK/ExponeaSDK/Classes/InAppMessages/View/InAppMessageWebView.swift
+++ b/ExponeaSDK/ExponeaSDK/Classes/InAppMessages/View/InAppMessageWebView.swift
@@ -89,6 +89,8 @@ final class InAppMessageWebView: UIView, InAppMessageView, WKNavigationDelegate 
         preferences.javaScriptCanOpenWindowsAutomatically = false
         preferences.javaScriptEnabled = false
 
+        // In Xcode 14 (Swift 5.7) is `preferences.isElementFullscreenEnabled` available in iOS 15.4 and above,
+        // while in older versions it was available in 15.0 and above, therefore we need to check for Swift version
         #if swift(>=5.7)
         if #available(iOS 15.4, *) {
             preferences.isElementFullscreenEnabled = false

--- a/ExponeaSDK/ExponeaSDK/Classes/InAppMessages/View/InAppMessageWebView.swift
+++ b/ExponeaSDK/ExponeaSDK/Classes/InAppMessages/View/InAppMessageWebView.swift
@@ -88,9 +88,17 @@ final class InAppMessageWebView: UIView, InAppMessageView, WKNavigationDelegate 
         let preferences = WKPreferences()
         preferences.javaScriptCanOpenWindowsAutomatically = false
         preferences.javaScriptEnabled = false
+
+        #if swift(>=5.7)
+        if #available(iOS 15.4, *) {
+            preferences.isElementFullscreenEnabled = false
+        }
+        #else
         if #available(iOS 15.0, *) {
             preferences.isElementFullscreenEnabled = false
         }
+        #endif
+
         let configuration = WKWebViewConfiguration()
         configuration.preferences = preferences
         configuration.allowsAirPlayForMediaPlayback = false


### PR DESCRIPTION
This PR addresses #38 and #37. These issues are present in App Store version of Xcode 14.

Change is non-breaking as using older versions of Swift/Xcode will check availability against iOS 15.0, while current version will check against 15.4.