### PR TITLE
Xcode 14.2 compiler explicit self capture

### DIFF
--- a/ExponeaSDK/ExponeaSDK/Classes/Exponea+Configuration.swift
+++ b/ExponeaSDK/ExponeaSDK/Classes/Exponea+Configuration.swift
@@ -192,7 +192,7 @@ public extension ExponeaInternal {
             
             do {
                 var willRunSelfCheck = false
-                if isDebugModeEnabled {
+                if self.isDebugModeEnabled {
                     willRunSelfCheck = self.checkPushSetup && pushNotificationTracking.isEnabled
                 }
 


### PR DESCRIPTION
To be able to build Exponea on Xcode 14.2 ( < Swift 5.8) we need to capture self explicitly.