### PR TITLE
Fixes issue https://github.com/exponea/exponea-ios-sdk/issues/69

### DIFF
--- a/ExponeaSDK/ExponeaSDK-Notifications/Supporting Files/PrivacyInfo.xcprivacy
+++ b/ExponeaSDK/ExponeaSDK-Notifications/Supporting Files/PrivacyInfo.xcprivacy
@@ -9,7 +9,6 @@
 		<dict>
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
-				<string>C617.1</string>
 				<string>CA92.1</string>
 			</array>
 			<key>NSPrivacyAccessedAPIType</key>

--- a/ExponeaSDK/ExponeaSDK/Supporting Files/PrivacyInfo.xcprivacy
+++ b/ExponeaSDK/ExponeaSDK/Supporting Files/PrivacyInfo.xcprivacy
@@ -9,7 +9,6 @@
 		<dict>
 			<key>NSPrivacyAccessedAPITypeReasons</key>
 			<array>
-				<string>C617.1</string>
 				<string>CA92.1</string>
 			</array>
 			<key>NSPrivacyAccessedAPIType</key>


### PR DESCRIPTION
### Description:
This pull request addresses an issue where the exponea-ios-sdk generates incorrect values ("C617.1") for the NSPrivacyAccessedAPICategoryUserDefaults category in the auto-generated PrivacyInfo.xcprivacy file within react-native projects. These incorrect values lead to an "Invalid Binary" error during App Store submission due to non-compliance with Apple's privacy guidelines.

### Changes:

Updated PrivacyInfo.xcprivacy files: Corrected the values in the following files to accurately reflect the usage of NSUserDefaults:
ExponeaSDK/ExponeaSDK/Supporting Files/PrivacyInfo.xcprivacy
ExponeaSDK/ExponeaSDK-Notifications/Supporting Files/PrivacyInfo.xcprivacy