### PR TITLE
Fix "Missing required module" error in SPM integration for modular architectures

### DIFF
--- a/ExponeaSDK/ExponeaSDK/Classes/ExponeaInternal.swift
+++ b/ExponeaSDK/ExponeaSDK/Classes/ExponeaInternal.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 #if canImport(ExponeaSDKObjC)
-import ExponeaSDKObjC
+internal import ExponeaSDKObjC
 #endif
 import UIKit
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/scinfu/SwiftSoup.git",
         "state": {
           "branch": null,
-          "revision": "8b6cf29eead8841a1fa7822481cb3af4ddaadba6",
-          "version": "2.6.1"
+          "revision": "3c2c7e1e72b8abd96eafbae80323c5c1e5317437",
+          "version": "2.7.5"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.9
 
 import PackageDescription
 
@@ -26,7 +26,10 @@ let package = Package(
             dependencies: ["ExponeaSDKShared", "ExponeaSDKObjC"],
             path: "ExponeaSDK/ExponeaSDK",
             exclude: ["Supporting Files/Info.plist"],
-            resources: [.copy("Supporting Files/PrivacyInfo.xcprivacy")]
+            resources: [.copy("Supporting Files/PrivacyInfo.xcprivacy")],
+            swiftSettings: [
+                .enableExperimentalFeature("AccessLevelOnImport")
+            ]
         ),
         // Notification extension library
         .target(


### PR DESCRIPTION
## Problem Encountered

When integrating the ExponeaSDK into a framework (not directly into an app) using Swift Package Manager (SPM), I encountered the following error:

```
product 'ExponeaSDKObjC' required by package 'myframework' target 'MyFramework' not found in package 'exponea-ios-sdk'. Did you mean 'ExponeaSDKObjC'?
```

## Explanation

This error likely occurs because of how Swift Package Manager handles dependencies. The `ExponeaSDKObjC` module, is [being unintentionally exposed and treated as a public dependency to clients of the SDK](https://forums.swift.org/t/issue-with-third-party-dependencies-inside-a-xcframework-through-swiftpm/41977/3) when used in a modular architecture.

Swift has recently introduced a new feature to address this scenario: "Access-level modifiers on import declarations", described in the Swift Evolution proposal [SE-0409](https://github.com/apple/swift-evolution/blob/main/proposals/0409-access-level-on-imports.md).

## Proposed Solution

To resolve this issue and improve the SDK's structure, I propose the following changes:

1. Update the `swift-tools-version` in `Package.swift` to 5.9.
2. Enable the experimental feature `AccessLevelOnImport` in the package targets. (No longer experimental from Swift 6.)
3. Add `internal import ExponeaSDKObjC` into `ExponeaInternal` where `ExponeaSDKObjC` is used.

## Alternative Solutions

### 1. Using `@_implementationOnly`

We could use the `@_implementationOnly` attribute:

```swift
@_implementationOnly import ExponeaSDKObjC
```

Pros:
- Works with older Swift versions
- Doesn't require changes to `Package.swift`

Cons:
- Uses an unofficial, underscored attribute
- May lead to instability or runtime crashes in certain scenarios
- Doesn't leverage the latest Swift features

### 2. Conditional Compilation

We could use conditional compilation to support both older and newer Swift versions:

```swift
#if swift(>=5.9)
internal import ExponeaSDKObjC
#else
@_implementationOnly import ExponeaSDKObjC
#endif
```

I'm not sure of the `Package.swift` definition in this case, maybe something like this could work.

```swift
...
swiftSettings: [
    .define("SWIFT_PACKAGE"),
    .unsafeFlags(["-enable-experimental-feature", "AccessLevelOnImport"], .when(platforms: [.iOS], configuration: .release))
]
...
```


Pros:
- Supports both older and newer Swift versions
- Allows gradual adoption of the new feature

Cons:
- Increases code complexity
- Requires maintaining two different import styles
- May lead to inconsistent behavior across different Swift versions

## Conclusion

The proposed solution (updating to Swift 5.9 and using `internal import`) provides the cleanest and most forward-looking fix. It leverages Swift's latest features to solve the problem in a way that's both official and future-proof.

This change will require users of the ExponeaSDK to use Xcode 15 or later. Given the benefits of the new feature and the cleaner code structure it allows, I believe this trade-off is worthwhile, especially for users with modular architectures.
